### PR TITLE
[PA-842]Added preset to make tags required

### DIFF
--- a/ckanext/custom_schema/schemas/dataset.yaml
+++ b/ckanext/custom_schema/schemas/dataset.yaml
@@ -34,7 +34,7 @@ dataset_fields:
 #  Use core CKAN free-form tag field
 - field_name: tag_string
   label: Tags
-  preset: tag_string_autocomplete
+  preset: tag_string_autocomplete_required
   form_placeholder: eg. economy, mental health, government
   required: True
 

--- a/ckanext/custom_schema/schemas/presets.yaml
+++ b/ckanext/custom_schema/schemas/presets.yaml
@@ -30,3 +30,11 @@ presets:
     display_snippet: group.html
     output_validators: scheming_required
 
+- preset_name: tag_string_autocomplete_required
+  values: 
+    validators: not_empty tag_string_convert
+    classes: control-full
+    form_attrs: 
+      data-module: autocomplete
+      data-module-tags: 
+      data-module-source: /api/2/util/tag/autocomplete?incomplete=?


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [PA-842](https://opengovinc.atlassian.net/browse/PA-842)

## Description
<!--- Describe these changes in detail --->
When making some metadata fields required for CDT, there was a bug where tags (required) was allowed to be blank when creating a dataset. This PR addresses that issue by adding a preset that makes sure the field cannot be empty.

## Test Procedure
<!--- List the steps involved to test the changes ---> 
IN THIS DIRECTOY `python setup.py develop`
1. In your ini file, enable `custom_schema`  and `scheming_datasets`. Make sure these come before `og-theme`
2. Go to Dataset page and click Add Dataset
3. Try to create a dataset without tags being filled in and make sure an error message pops up.
4. Fill in the tags field and create the dataset.

# Approval Criteria 
<!--- Describe the expected results of testing --->
You are able to create a dataset and are required to fill out tags along with Frequency, Public Access Level, and Rights field. 

## Submitter Checklist
- [ ] The code looks good to me (LGTM)
- [ ] I have tested the changes locally
- [ ] The new changes does not affect web accessibility
