### PR TITLE
[PA-889] Add custom validator for required tags

### DIFF
--- a/ckanext/custom_schema/plugins.py
+++ b/ckanext/custom_schema/plugins.py
@@ -1,9 +1,23 @@
-from ckan.plugins import toolkit, IConfigurer, IRoutes, IPackageController, SingletonPlugin, implements, toolkit
+from ckan.plugins import (
+    toolkit,
+    IConfigurer,
+    IRoutes,
+    IPackageController,
+    IValidators,
+    SingletonPlugin,
+    implements,
+    toolkit
+)
+
+from ckanext.custom_schema.validators import (
+    tag_not_empty
+)
 
 class customSchema(SingletonPlugin):
     implements(IConfigurer)
     implements(IRoutes,inherit=True)
     implements(IPackageController, inherit=True)
+    implements(IValidators)
 
     def update_config(self, config):
         toolkit.add_public_directory(config, "static")
@@ -57,3 +71,7 @@ ckanext.custom_schema:schemas/dataset.yaml
             if group['name'] != package['group']:
                 toolkit.get_action('member_delete')(context, {'id': group['id'], 'object': package['id'], 'object_type': 'package'})
 
+    def get_validators(self):
+        return {
+            'tag_not_empty': tag_not_empty
+            }

--- a/ckanext/custom_schema/schemas/presets.yaml
+++ b/ckanext/custom_schema/schemas/presets.yaml
@@ -32,8 +32,8 @@ presets:
 
 - preset_name: tag_string_autocomplete_required
   values: 
-    validators: not_empty tag_string_convert
-    classes: control-full
+    validators: tag_not_empty tag_string_convert
+    classes: [control-full]
     form_attrs: 
       data-module: autocomplete
       data-module-tags: 

--- a/ckanext/custom_schema/validators.py
+++ b/ckanext/custom_schema/validators.py
@@ -10,6 +10,8 @@ not_empty = get_validator('not_empty')
 
 @scheming_validator
 def tag_not_empty(field, schema):
+    # Default validator for tag_string is not_empty
+    # If tag_string is empty set it to current package tags
     def validator(key, data, errors, context):
         # get list of tags from tag_string
         if isinstance(data[key], string_types):
@@ -19,14 +21,16 @@ def tag_not_empty(field, schema):
         else:
             tags = data[key]
 
-        # ignore missing tag_string if tags is present
+        # check if tag_string is missing or empty
         if tags is missing or not tags:
             package = context.get('package')
+            # check if there's a package
             if package:
                 model = context['model']
                 session = context['session']
                 pkg = session.query(model.Package).get(package.id)
                 pkg_tags = pkg.get_tags()
+                # check if package has tags and adds them to tag_string
                 if pkg_tags:
                     tag_list = [t.name for t in pkg_tags]
                     data[key] = ",".join(tag_list)

--- a/ckanext/custom_schema/validators.py
+++ b/ckanext/custom_schema/validators.py
@@ -28,6 +28,8 @@ def tag_not_empty(field, schema):
                 pkg = session.query(model.Package).get(package.id)
                 pkg_tags = pkg.get_tags()
                 if pkg_tags:
+                    tag_list = [t.name for t in pkg_tags]
+                    data[key] = ",".join(tag_list)
                     return ignore_missing(key, data, errors, context)
 
         return not_empty(key, data, errors, context)

--- a/ckanext/custom_schema/validators.py
+++ b/ckanext/custom_schema/validators.py
@@ -1,0 +1,35 @@
+from six import string_types
+
+from ckan.plugins.toolkit import missing, _, get_validator
+
+from ckanext.scheming.validation import scheming_validator
+
+ignore_missing = get_validator('ignore_missing')
+not_empty = get_validator('not_empty')
+
+
+@scheming_validator
+def tag_not_empty(field, schema):
+    def validator(key, data, errors, context):
+        # get list of tags from tag_string
+        if isinstance(data[key], string_types):
+            tags = [tag.strip() \
+                    for tag in data[key].split(',') \
+                    if tag.strip()]
+        else:
+            tags = data[key]
+
+        # ignore missing tag_string if tags is present
+        if tags is missing or not tags:
+            package = context.get('package')
+            if package:
+                model = context['model']
+                session = context['session']
+                pkg = session.query(model.Package).get(package.id)
+                pkg_tags = pkg.get_tags()
+                if pkg_tags:
+                    return ignore_missing(key, data, errors, context)
+
+        return not_empty(key, data, errors, context)
+
+    return validator


### PR DESCRIPTION
<!--- The following labels will blacklist a PR from https://ci.opengov.ninja/job/voltron-pr-detect-pipe --->
<!--- 1) Jenkins Blacklist --->
<!--- 2) Do Not Merge --->
<!--- 3) Work In Progress --->
<!--- 4) Blocked --->
<!--- 4) Needs Peer Review --->
<!--- 4) Platform Pipeline --->

<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [TICKET](https://opengovinc.atlassian.net/browse/PA-889)

## Description
<!--- Describe these changes in detail --->
This PR fixes a bug with required tags that prevents updates to resources.

<img width="946" alt="Screen Shot 2019-10-28 at 11 35 20 AM" src="https://user-images.githubusercontent.com/4096633/67692821-1d545000-f977-11e9-9807-262fce084f9e.png">

The "tag_string" field is a comma separated list of strings that is converted to to the "tags" field. The next time the dataset is updated the "tag_string" won't be set but the "tags" field will. This means when resource_update is called it will fail due to "tag_string" being missing.

To fix this we'll add a validator that checks if "tag_string" is empty. If it is empty then it sets "tag_string" to the dataset's current tags. If the dataset currently has no tags then the `not_empty` validator is used.

## Testing
- Checkout this PR
- Create a new dataset and set all fields except tags
  - It should fail with an error `Tags: Missing value`
- Update a existing dataset by removing all tags
  - After the update the tags should still remain
- Update a resource's title or format
  - It should succeed without an error about `tag_string`
