### PR TITLE
[OD-1611] Fix topic field in CDT schema

### DIFF
--- a/ckanext/custom_schema/helpers.py
+++ b/ckanext/custom_schema/helpers.py
@@ -1,0 +1,16 @@
+import ckan.plugins as p
+
+get_action = p.toolkit.get_action
+ValidationError = p.toolkit.ValidationError
+
+def get_group_list():
+    try:
+        data_dict_global_results = {
+            'all_fields': True,
+            'sort': 'title asc',
+            'type': 'group',
+        }
+        global_results = get_action('group_list')({}, data_dict_global_results)
+        return global_results
+    except ValidationError:
+        return []

--- a/ckanext/custom_schema/helpers.py
+++ b/ckanext/custom_schema/helpers.py
@@ -14,3 +14,13 @@ def get_group_list():
         return global_results
     except ValidationError:
         return []
+
+def get_selected_group(data):
+    try:
+        group_list = data.get('groups', [])
+        for item in group_list:
+            if item.get('name'):
+                return item.get('name')
+    except TypeError, ValueError:
+        pass
+    return ''

--- a/ckanext/custom_schema/plugins.py
+++ b/ckanext/custom_schema/plugins.py
@@ -50,7 +50,6 @@ ckanext.custom_schema:schemas/dataset.yaml
 
     # IPackageController
     def after_create(self, context, pkg_dict):
-        user = context.get('user')
         group_name = pkg_dict.get('group')
 
         # Add dataset to "groups" based on custom field "group"
@@ -67,13 +66,12 @@ ckanext.custom_schema:schemas/dataset.yaml
             raise toolkit.ValidationError({
                 'message': [
                     'User "{0}" not authorized to add dataset to topic {1}'.format(
-                        user, group_name
+                        context.get('user'), group_name
                     )
                 ]
             })
 
     def after_update(self, context, pkg_dict):
-        user = context.get('user')
         group_name = pkg_dict.get('group')
 
         if group_name:
@@ -95,7 +93,7 @@ ckanext.custom_schema:schemas/dataset.yaml
                     raise toolkit.ValidationError({
                         'message': [
                             'User "{0}" not authorized to add dataset to topic {1}'.format(
-                                user, group_name
+                                context.get('user'), group_name
                             )
                         ]
                     })
@@ -114,7 +112,7 @@ ckanext.custom_schema:schemas/dataset.yaml
                     raise toolkit.ValidationError({
                         'message': [
                             'User "{0}" not authorized to remove dataset from topic {1}'.format(
-                                user, group_dict.get('name')
+                                context.get('user'), group_dict.get('name')
                             )
                         ]
                     })

--- a/ckanext/custom_schema/plugins.py
+++ b/ckanext/custom_schema/plugins.py
@@ -1,24 +1,27 @@
 from ckan.plugins import (
     toolkit,
+    implements,
     IConfigurer,
     IRoutes,
     IPackageController,
     IValidators,
-    SingletonPlugin,
-    implements,
-    toolkit
+    ITemplateHelpers,
+    SingletonPlugin
 )
-
 from ckanext.custom_schema.validators import (
     tag_not_empty
 )
+import ckanext.custom_schema.helpers as schema_helpers
+
 
 class customSchema(SingletonPlugin):
     implements(IConfigurer)
-    implements(IRoutes,inherit=True)
+    implements(IRoutes, inherit=True)
     implements(IPackageController, inherit=True)
     implements(IValidators)
+    implements(ITemplateHelpers)
 
+    # IConfigurer
     def update_config(self, config):
         toolkit.add_public_directory(config, "static")
         toolkit.add_template_directory(config, "templates")
@@ -33,6 +36,7 @@ ckanext.custom_schema:schemas/presets.yaml
 ckanext.custom_schema:schemas/dataset.yaml
 """
 
+    # IRoutes
     def before_map(self,m):
         m.connect(
             '/metadata_download/{package_id}',
@@ -43,35 +47,63 @@ ckanext.custom_schema:schemas/dataset.yaml
 
     # IPackageController
     def after_create(self, context, pkg_dict):
-        if 'group' in pkg_dict:
-            if pkg_dict['group']:
-                data = {
-                    'id': pkg_dict['group'],
+        user = context.get('user')
+        group_name = pkg_dict.get('group')
+
+        # Add dataset to "groups" based on custom field "group"
+        try:
+            if group_name:
+                data_dict = {
+                    'id': group_name,
                     'object': pkg_dict['id'],
                     'object_type': 'package',
                     'capacity': 'public'
                 }
-                toolkit.get_action('member_create')(context, data)
+                toolkit.get_action('member_create')(context, data_dict)
+        except toolkit.NotAuthorized:
+            raise toolkit.ValidationError({
+                'message': ['User {0} not authorized to add dataset to topic {1}'.format(user, group_name)]
+            })
 
     def after_update(self, context, pkg_dict):
-        if 'group' in pkg_dict:
-            if pkg_dict['group']:
-                data = {
-                    'id': pkg_dict['group'],
-                    'object': pkg_dict['id'],
-                    'object_type': 'package',
-                    'capacity': 'public'
-                }
-                toolkit.get_action('member_create')(context, data)
-            self.remove_from_other_groups(context, pkg_dict['id'])
+        user = context.get('user')
+        group_name = pkg_dict.get('group')
 
-    def remove_from_other_groups(self, context, package_id):
-        package = toolkit.get_action('package_show')(context, {'id': package_id})
-        for group in package['groups']:
-            if group['name'] != package['group']:
-                toolkit.get_action('member_delete')(context, {'id': group['id'], 'object': package['id'], 'object_type': 'package'})
+        if group_name:
+            existing_package = toolkit.get_action('package_show')(context, {'id': pkg_dict.get('id')})
+            existing_groups = existing_package.get('groups', [])
+            is_group_set = False
 
+            # Check if group is in current groups
+            for existing_group_dict in existing_groups:
+                if existing_group_dict.get('name') == group_name:
+                    is_group_set = True
+                    break
+
+            # Add dataset to "groups" based on custom field "group"
+            if not is_group_set:
+                try:
+                    data_dict = {
+                        'id': group_name,
+                        'object': pkg_dict['id'],
+                        'object_type': 'package',
+                        'capacity': 'public'
+                    }
+                    toolkit.get_action('member_create')(context, data_dict)
+                except toolkit.NotAuthorized:
+                    raise toolkit.ValidationError({
+                        'message': ['User {0} not authorized to add dataset to topic {1}'.format(user, group_name)]
+                    })
+
+
+    # IValidators
     def get_validators(self):
         return {
             'tag_not_empty': tag_not_empty
             }
+
+    # ITemplateHelpers
+    def get_helpers(self):
+        return {
+            'og_get_group_list': schema_helpers.get_group_list
+        }

--- a/ckanext/custom_schema/plugins.py
+++ b/ckanext/custom_schema/plugins.py
@@ -124,6 +124,7 @@ ckanext.custom_schema:schemas/dataset.yaml
             'tag_not_empty': tag_not_empty
             }
 
+
     # ITemplateHelpers
     def get_helpers(self):
         return {

--- a/ckanext/custom_schema/schemas/dataset.yaml
+++ b/ckanext/custom_schema/schemas/dataset.yaml
@@ -46,7 +46,7 @@ dataset_fields:
 
 ## "topics"
 - field_name: group
-  label: Add to Topic
+  label: Topic
   preset: group
   help_text: For data curation purposes users should be a member of a topic to add a dataset to the topic
 

--- a/ckanext/custom_schema/schemas/dataset.yaml
+++ b/ckanext/custom_schema/schemas/dataset.yaml
@@ -46,8 +46,9 @@ dataset_fields:
 
 ## "topics"
 - field_name: group
-  label: Topic
+  label: Add to Topic
   preset: group
+  help_text: For data curation purposes users should be a member of a topic to add a dataset to the topic
 
 ## "department"
 #  The Publisher field will be mapped to CKAN organizations

--- a/ckanext/custom_schema/schemas/presets.yaml
+++ b/ckanext/custom_schema/schemas/presets.yaml
@@ -28,7 +28,7 @@ presets:
   values: 
     form_snippet: group.html
     display_snippet: group.html
-    output_validators: scheming_required
+    validators: ignore_missing
 
 - preset_name: tag_string_autocomplete_required
   values: 

--- a/ckanext/custom_schema/templates/scheming/form_snippets/group.html
+++ b/ckanext/custom_schema/templates/scheming/form_snippets/group.html
@@ -1,6 +1,5 @@
 {% set error = errors[field.field_name] %}
-{% set sel = data[field.field_name] or '' %}
-{% set groups = h.groups_available(True) or [] %}
+{% set groups = h.og_get_group_list() or [] %}
 
 <div class="control-group{% if error %} error{% endif %}" >
     <label class="control-label" for="field-{{ field.field_name }}">
@@ -10,13 +9,12 @@
         {{ h.scheming_language_text(field.label) }}
     </label>
     <div class="controls">
-        <select id="field-{{ field.field_name }}" name="{{ field.field_name }}">\
+        <select id="field-{{ field.field_name }}" name="{{ field.field_name }}">
             <option></option>
             {% for group in groups %}
-                <option value="{{group.name}}"{% if group.name==sel %} selected="selected"{% endif %}>{{group.title}}</option>
+                <option value="{{group.name}}">{{group.title}}</option>
             {% endfor %}
         </select>
         {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
     </div>
 </div>
-

--- a/ckanext/custom_schema/templates/scheming/form_snippets/group.html
+++ b/ckanext/custom_schema/templates/scheming/form_snippets/group.html
@@ -1,4 +1,5 @@
 {% set error = errors[field.field_name] %}
+{% set selected_group_name = h.og_get_selected_group(data) %}
 {% set groups = h.og_get_group_list() or [] %}
 
 <div class="control-group{% if error %} error{% endif %}" >
@@ -12,7 +13,7 @@
         <select id="field-{{ field.field_name }}" name="{{ field.field_name }}">
             <option></option>
             {% for group in groups %}
-                <option value="{{group.name}}">{{group.title}}</option>
+                <option value="{{group.name}}"{% if group.name==selected_group_name %} selected="selected"{% endif %}>{{group.title}}</option>
             {% endfor %}
         </select>
         {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}

--- a/ckanext/custom_schema/tests/test_dataset_logic.py
+++ b/ckanext/custom_schema/tests/test_dataset_logic.py
@@ -1,0 +1,68 @@
+import ckan.lib.search
+from ckantoolkit.tests import helpers, factories
+
+
+class TestPackageWithGroupModifier(object):
+    @classmethod
+    def setup(self):
+        helpers.reset_db()
+        ckan.lib.search.clear_all()
+
+    @classmethod
+    def teardown(self):
+        helpers.reset_db()
+        ckan.lib.search.clear_all()
+
+    def test_package_create_without_any_group_modifier(self):
+        dataset = factories.Dataset(
+            name='test-dataset-1',
+            tag_string='geography',
+            accessLevel='public',
+            contact_name='John Smith',
+            contact_email='jsmith@test.com',
+            rights='No restrictions on public use',
+            accrualPeriodicity='R/P1W'
+        )
+
+        assert dataset['groups'] == []
+
+    def test_package_create_with_group_modifier(self):
+        group1 = factories.Group(name='economy')
+        dataset = factories.Dataset(
+            name='test-dataset-2',
+            tag_string='geography',
+            accessLevel='public',
+            contact_name='John Smith',
+            contact_email='jsmith@test.com',
+            rights='No restrictions on public use',
+            accrualPeriodicity='R/P1W',
+            group='economy'
+        )
+
+        assert dataset['groups'][0]['name'] == 'economy'
+
+    def test_package_patch_with_group_modifier(self):
+        group1 = factories.Group(name='economy')
+        group2 = factories.Group(name='transportation')
+        group3 = factories.Group(name='water')
+        dataset = factories.Dataset(
+            name='test-dataset-3',
+            tag_string='geography',
+            accessLevel='public',
+            contact_name='John Smith',
+            contact_email='jsmith@test.com',
+            rights='No restrictions on public use',
+            accrualPeriodicity='R/P1W',
+            group='economy'
+        )
+
+        assert dataset['groups'][0]['name'] == 'economy'
+
+        dataset = helpers.call_action(
+            'package_patch',
+            id='test-dataset-3',
+            group='transportation'
+        )
+
+        assert dataset['groups'][0]['name'] == 'transportation'
+        assert len(dataset['groups']) == 1

--- a/ckanext/custom_schema/tests/test_dataset_logic.py
+++ b/ckanext/custom_schema/tests/test_dataset_logic.py
@@ -1,5 +1,10 @@
 import ckan.lib.search
 from ckantoolkit.tests import helpers, factories
+from ckan.plugins.toolkit import ValidationError
+
+import nose.tools
+
+assert_raises = nose.tools.assert_raises
 
 
 class TestPackageWithGroupModifier(object):
@@ -66,3 +71,128 @@ class TestPackageWithGroupModifier(object):
 
         assert dataset['groups'][0]['name'] == 'transportation'
         assert len(dataset['groups']) == 1
+
+
+class TestUserAuthWithGroupModifier(object):
+    @classmethod
+    def setup(self):
+        helpers.reset_db()
+        ckan.lib.search.clear_all()
+
+    @classmethod
+    def teardown(self):
+        helpers.reset_db()
+        ckan.lib.search.clear_all()
+
+    def test_package_create_without_group_permission(self):
+        user = factories.User(name='user1')
+        owner_org = factories.Organization(
+            users=[
+                {'name': user['name'], 'capacity': 'editor'}
+            ]
+        )
+        group = factories.Group(name='economy')
+
+        context = {'user': user['name'], 'ignore_auth': False}
+        params = {
+            'name': 'test-dataset-1',
+            'notes': 'This is a test',
+            'tag_string': 'geography',
+            'accessLevel': 'public',
+            'contact_name': 'John Smith',
+            'contact_email': 'jsmith@test.com',
+            'rights': 'No restrictions on public use',
+            'accrualPeriodicity': 'R/P1W',
+            'owner_org': owner_org['id'],
+            'group': 'economy'
+        }
+
+        assert_raises(
+            ValidationError,
+            helpers.call_action, 'package_create', context, **params
+        )
+
+    def test_package_create_with_group_permission(self):
+        user = factories.User(name='user2')
+        owner_org = factories.Organization(
+            users=[
+                {'name': user['name'], 'capacity': 'editor'}
+            ]
+        )
+        group = factories.Group(
+            name='economy',
+            users=[
+                {'name': user['name'], 'capacity': 'member'}
+            ]
+        )
+
+        context = {'user': user['name'], 'ignore_auth': False}
+        params = {
+            'name': 'test-dataset-2',
+            'notes': 'This is a test',
+            'tag_string': 'geography',
+            'accessLevel': 'public',
+            'contact_name': 'John Smith',
+            'contact_email': 'jsmith@test.com',
+            'rights': 'No restrictions on public use',
+            'accrualPeriodicity': 'R/P1W',
+            'owner_org': owner_org['id'],
+            'group': 'economy'
+        }
+        dataset = helpers.call_action(
+            'package_create',
+            context=context,
+            **params
+        )
+
+        assert dataset['groups'][0]['name'] == 'economy'
+
+    def test_package_patch_with_group_permission(self):
+        user = factories.User(name='user3')
+        owner_org = factories.Organization(
+            users=[
+                {'name': user['name'], 'capacity': 'editor'}
+            ]
+        )
+        group1 = factories.Group(
+            name='economy',
+            users=[
+                {'name': user['name'], 'capacity': 'member'}
+            ]
+        )
+        group2 = factories.Group(
+            name='transportation',
+            users=[
+                {'name': user['name'], 'capacity': 'member'}
+            ]
+        )
+
+        context = {'user': user['name'], 'ignore_auth': False}
+        create_params = {
+            'name': 'test-dataset-3',
+            'notes': 'This is a test',
+            'tag_string': 'geography',
+            'accessLevel': 'public',
+            'contact_name': 'John Smith',
+            'contact_email': 'jsmith@test.com',
+            'rights': 'No restrictions on public use',
+            'accrualPeriodicity': 'R/P1W',
+            'owner_org': owner_org['id'],
+            'group': 'economy'
+        }
+        dataset = helpers.call_action(
+            'package_create',
+            context=context,
+            **create_params
+        )
+
+        patch_params = {
+            'id': 'test-dataset-3',
+            'group': 'transportation'
+        }
+        dataset = helpers.call_action(
+            'package_patch',
+            context=context,
+            **patch_params
+        )
+        assert dataset['groups'][0]['name'] == 'transportation'

--- a/ckanext/custom_schema/tests/test_helpers.py
+++ b/ckanext/custom_schema/tests/test_helpers.py
@@ -19,24 +19,17 @@ class TestGetGroupList(object):
         ckan.lib.search.clear_all()
 
     def test_group_list_no_results(self):
-        assert (
-            get_group_list() == []
-        )
+        assert get_group_list() == []
 
     def test_group_list_with_results(self):
         group1 = factories.Group(name='water')
         group2 = factories.Group(name='transportation')
         group3 = factories.Group(name='economy')
         group_from_helpers = get_group_list()
-        assert (
-            group_from_helpers[0]['name'] == 'economy'
-        )
-        assert (
-            group_from_helpers[1]['name'] == 'transportation'
-        )
-        assert (
-            group_from_helpers[2]['name'] == 'water'
-        )
+
+        assert group_from_helpers[0]['name'] == 'economy'
+        assert group_from_helpers[1]['name'] == 'transportation'
+        assert group_from_helpers[2]['name'] == 'water'
 
 
 class TestGetSelectedGroup(object):
@@ -59,9 +52,8 @@ class TestGetSelectedGroup(object):
             rights='No restrictions on public use',
             accrualPeriodicity='R/P1W'
         )
-        assert (
-            get_selected_group(dataset) == ''
-        )
+
+        assert get_selected_group(dataset) == ''
 
     def test_selected_group_with_several_groups(self):
         group1 = factories.Group(name='economy')
@@ -79,6 +71,5 @@ class TestGetSelectedGroup(object):
                 {'name': group3['name']}
             ]
         )
-        assert (
-            get_selected_group(dataset) == 'transportation'
-        )
+
+        assert get_selected_group(dataset) == 'transportation'

--- a/ckanext/custom_schema/tests/test_helpers.py
+++ b/ckanext/custom_schema/tests/test_helpers.py
@@ -1,0 +1,84 @@
+import ckan.lib.search
+from ckantoolkit.tests import helpers, factories
+
+from ckanext.custom_schema.helpers import (
+    get_group_list,
+    get_selected_group
+)
+
+
+class TestGetGroupList(object):
+    @classmethod
+    def setup(self):
+        helpers.reset_db()
+        ckan.lib.search.clear_all()
+
+    @classmethod
+    def teardown(self):
+        helpers.reset_db()
+        ckan.lib.search.clear_all()
+
+    def test_group_list_no_results(self):
+        assert (
+            get_group_list() == []
+        )
+
+    def test_group_list_with_results(self):
+        group1 = factories.Group(name='water')
+        group2 = factories.Group(name='transportation')
+        group3 = factories.Group(name='economy')
+        group_from_helpers = get_group_list()
+        assert (
+            group_from_helpers[0]['name'] == 'economy'
+        )
+        assert (
+            group_from_helpers[1]['name'] == 'transportation'
+        )
+        assert (
+            group_from_helpers[2]['name'] == 'water'
+        )
+
+
+class TestGetSelectedGroup(object):
+    @classmethod
+    def setup(self):
+        helpers.reset_db()
+        ckan.lib.search.clear_all()
+
+    @classmethod
+    def teardown(self):
+        helpers.reset_db()
+        ckan.lib.search.clear_all()
+
+    def test_selected_group_with_no_groups(self):
+        dataset = factories.Dataset(
+            tag_string='geography',
+            accessLevel='public',
+            contact_name='John Smith',
+            contact_email='jsmith@test.com',
+            rights='No restrictions on public use',
+            accrualPeriodicity='R/P1W'
+        )
+        assert (
+            get_selected_group(dataset) == ''
+        )
+
+    def test_selected_group_with_several_groups(self):
+        group1 = factories.Group(name='economy')
+        group2 = factories.Group(name='transportation')
+        group3 = factories.Group(name='water')
+        dataset = factories.Dataset(
+            tag_string='geography',
+            accessLevel='public',
+            contact_name='John Smith',
+            contact_email='jsmith@test.com',
+            rights='No restrictions on public use',
+            accrualPeriodicity='R/P1W',
+            groups=[
+                {'name': group2['name']},
+                {'name': group3['name']}
+            ]
+        )
+        assert (
+            get_selected_group(dataset) == 'transportation'
+        )

--- a/test.ini
+++ b/test.ini
@@ -1,0 +1,4 @@
+[app:main]
+use = config:../ckan/test-core.ini
+
+ckan.plugins = custom_schema scheming_datasets


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [TICKET](https://opengovinc.atlassian.net/browse/OD-1611)

## Description
<!--- Describe these changes in detail --->
This PR fixes a bug where users that update a dataset will experience a 403 forbidden error if the dataset belongs to a group the user is not a member of.

Now before calling `member_create` to add a dataset to a group we'll check if the dataset is already in the group. The topic dropdown menu will also display all groups instead of only groups the user has permission for.

There's also a new helper function to determine what the currently selected group should be in the dropdown. This is needed since the custom group field won't be updated if a user adds a dataset to a group using the `Group` tab or the API.