### PR TITLE
Add DCAT Modified and Issued date to CDT schema

### DIFF
--- a/ckanext/custom_schema/schemas/dataset.yaml
+++ b/ckanext/custom_schema/schemas/dataset.yaml
@@ -122,6 +122,8 @@ dataset_fields:
     value: R/P3.5D
   - label: Weekly
     value: R/P1W
+  - label: Biweekly
+    value: R/P2W
   - label: Semimonthly
     value: R/P0.5M
   - label: Monthly
@@ -131,13 +133,13 @@ dataset_fields:
   - label: Quarterly
     value: R/P3M
   - label: Semiannual
-    value:  R/P6M
+    value: R/P6M
   - label: Annual
-    value:  R/P1Y
+    value: R/P1Y
   - label: Biennial
-    value:  R/P2Y
+    value: R/P2Y
   - label: Decennial
-    value:  R/P10Y
+    value: R/P10Y
   required: True
     
 ## "temporalNotes"

--- a/ckanext/custom_schema/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/custom_schema/templates/scheming/package/snippets/additional_info.html
@@ -62,18 +62,12 @@
         {% endif %}
 
         {% block extras scoped %}
-          {% for extra in h.sorted_extras(pkg_dict.extras) %}
+          {% set sorted_extras = h.sorted_extras(pkg_dict.extras, subs={"dcat_issued": "DCAT Issued Date", "dcat_modified": "DCAT Modified Date"}) %}
+          {% for extra in sorted_extras %}
             {% set key, value = extra %}
-            {% if key == 'dcat_issued' %}
+            {% if key in ["DCAT Issued Date", "DCAT Modified Date"] %}
               <tr>
-                <th scope="row" class="dataset-label">{{ _("DCAT Issued Date") }}</th>
-                <td class="dataset-details">
-                  {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=value %}
-                </td>
-              </tr>
-            {% elif key == 'dcat_modified' %}
-              <tr>
-                <th scope="row" class="dataset-label">{{ _("DCAT Modified Date") }}</th>
+                <th scope="row" class="dataset-label">{{ key }}</th>
                 <td class="dataset-details">
                   {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=value %}
                 </td>

--- a/ckanext/custom_schema/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/custom_schema/templates/scheming/package/snippets/additional_info.html
@@ -48,19 +48,36 @@
           <tr>
             <th scope="row" class="dataset-label">{{ _("Last Updated") }}</th>
             <td class="dataset-details">
-                {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_modified %}
+              {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_modified %}
             </td>
           </tr>
         {% endif %}
         {% if pkg_dict.metadata_created %}
           <tr>
             <th scope="row" class="dataset-label">{{ _("Created") }}</th>
-
             <td class="dataset-details">
-                {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_created %}
+              {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_created %}
             </td>
           </tr>
         {% endif %}
+        {% for extra in h.sorted_extras(pkg_dict.extras) %}
+          {% set key, value = extra %}
+          {% if key == 'dcat_modified' %}
+            <tr>
+              <th scope="row" class="dataset-label">{{ _("DCAT Modified Date") }}</th>
+              <td class="dataset-details">
+                {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=value %}
+              </td>
+            </tr>
+          {% elif key == 'dcat_issued' %}
+            <tr>
+              <th scope="row" class="dataset-label">{{ _("DCAT Issued Date") }}</th>
+              <td class="dataset-details">
+                {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=value %}
+              </td>
+            </tr>
+          {% endif %}
+        {% endfor %}
     {% endblock %}
     </tbody>
   </table>

--- a/ckanext/custom_schema/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/custom_schema/templates/scheming/package/snippets/additional_info.html
@@ -60,24 +60,28 @@
             </td>
           </tr>
         {% endif %}
-        {% for extra in h.sorted_extras(pkg_dict.extras) %}
-          {% set key, value = extra %}
-          {% if key == 'dcat_modified' %}
-            <tr>
-              <th scope="row" class="dataset-label">{{ _("DCAT Modified Date") }}</th>
-              <td class="dataset-details">
-                {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=value %}
-              </td>
-            </tr>
-          {% elif key == 'dcat_issued' %}
-            <tr>
-              <th scope="row" class="dataset-label">{{ _("DCAT Issued Date") }}</th>
-              <td class="dataset-details">
-                {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=value %}
-              </td>
-            </tr>
-          {% endif %}
-        {% endfor %}
+
+        {% block extras scoped %}
+          {% for extra in h.sorted_extras(pkg_dict.extras) %}
+            {% set key, value = extra %}
+            {% if key == 'dcat_issued' %}
+              <tr>
+                <th scope="row" class="dataset-label">{{ _("DCAT Issued Date") }}</th>
+                <td class="dataset-details">
+                  {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=value %}
+                </td>
+              </tr>
+            {% elif key == 'dcat_modified' %}
+              <tr>
+                <th scope="row" class="dataset-label">{{ _("DCAT Modified Date") }}</th>
+                <td class="dataset-details">
+                  {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=value %}
+                </td>
+              </tr>
+            {% endif %}
+          {% endfor %}
+        {% endblock %}
+
     {% endblock %}
     </tbody>
   </table>


### PR DESCRIPTION
This PR adds the DCAT Modified and Issued date to the dataset Additional Info table. This helps users know when the harvested data was last modified in the source.

Also adds biweekly to accrualPeriodicity.
https://resources.data.gov/schemas/dcat-us/v1.1/iso8601_guidance/#accrualperiodicity

## Testing
Checkout this branch and view any dataset that was harvest using the DCAT JSON harvester.