### PR TITLE
Add DCAT modified to San Jose schema

### DIFF
--- a/ckanext/custom_schema/sanjose/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/custom_schema/sanjose/templates/scheming/package/snippets/additional_info.html
@@ -25,17 +25,35 @@
     {%- endif -%}
   {%- endfor -%}
 
-  {% if pkg_dict.metadata_modified %}
-    <tr>
-      <th scope="row" class="dataset-label">{{ _("Last Updated") }}</th>
-      <td class="dataset-details">{{ h.render_datetime(pkg_dict.metadata_modified) }}</td>
-    </tr>
-  {% endif %}
-
   {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
     <tr>
       <th scope="row" class="dataset-label">{{ _("State") }}</th>
       <td class="dataset-details">{{ _(pkg_dict.state) }}</td>
     </tr>
   {% endif %}
+
+  {% if pkg_dict.metadata_modified %}
+    <tr>
+      <th scope="row" class="dataset-label">{{ _("Last Updated") }}</th>
+      <td class="dataset-details">
+        {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_modified %}
+      </td>
+    </tr>
+  {% endif %}
+
+  {% block extras scoped %}
+    {% set sorted_extras = h.sorted_extras(pkg_dict.extras, subs={"dcat_modified": "DCAT Modified Date"}) %}
+    {% for extra in sorted_extras %}
+      {% set key, value = extra %}
+      {% if key in ["DCAT Modified Date"] %}
+        <tr>
+          <th scope="row" class="dataset-label">{{ key }}</th>
+          <td class="dataset-details">
+            {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=value %}
+          </td>
+        </tr>
+      {% endif %}
+    {% endfor %}
+  {% endblock %}
+
 {% endblock %}

--- a/ckanext/custom_schema/sanjose/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/custom_schema/sanjose/templates/scheming/package/snippets/additional_info.html
@@ -48,9 +48,7 @@
       {% if key in ["DCAT Modified Date"] %}
         <tr>
           <th scope="row" class="dataset-label">{{ key }}</th>
-          <td class="dataset-details">
-            {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=value %}
-          </td>
+          <td class="dataset-details">{{ value }}</td>
         </tr>
       {% endif %}
     {% endfor %}


### PR DESCRIPTION
Add DCAT modified date to San Jose additional info table.
Currently San Jose does not have created dates displayed.

This PR also has the following changes:
- Places the `Last Updated` field after `State` field like other CKAN sites.

## Testing
Checkout this branch and view any dataset that was harvest using the DCAT JSON harvester.